### PR TITLE
SwaggerEditor v1.2.0 - Adds SCC

### DIFF
--- a/stable/developer-dashboard/values.yaml
+++ b/stable/developer-dashboard/values.yaml
@@ -1,4 +1,4 @@
-# Default values for catalyst-dashboard.
+# Default values for swaggereditor.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 

--- a/stable/swaggereditor/Chart.yaml
+++ b/stable/swaggereditor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for installing Swagger Editor into a k8s compliant cluster
 name: swaggereditor
-version: 1.1.0
+version: 1.2.0

--- a/stable/swaggereditor/templates/NOTES.txt
+++ b/stable/swaggereditor/templates/NOTES.txt
@@ -4,16 +4,16 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "catalyst-dashboard.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "swaggereditor.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "catalyst-dashboard.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "catalyst-dashboard.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get svc -w {{ template "swaggereditor.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "swaggereditor.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "catalyst-dashboard.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "swaggereditor.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80
 {{- end }}

--- a/stable/swaggereditor/templates/_helpers.tpl
+++ b/stable/swaggereditor/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "catalyst-dashboard.name" -}}
+{{- define "swaggereditor.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -11,7 +11,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "catalyst-dashboard.fullname" -}}
+{{- define "swaggereditor.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -27,7 +27,7 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "catalyst-dashboard.chart" -}}
+{{- define "swaggereditor.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 

--- a/stable/swaggereditor/templates/deployment.yaml
+++ b/stable/swaggereditor/templates/deployment.yaml
@@ -1,33 +1,33 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "catalyst-dashboard.fullname" . }}
+  name: {{ include "swaggereditor.fullname" . }}
   labels:
-    app: {{ include "catalyst-dashboard.name" . }}
-    chart: {{ include "catalyst-dashboard.chart" . }}
+    app: {{ include "swaggereditor.name" . }}
+    chart: {{ include "swaggereditor.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    "app.kubernetes.io/name": {{ include "catalyst-dashboard.fullname" . }}
-    "helm.sh/chart": {{ include "catalyst-dashboard.chart" . }}
+    "app.kubernetes.io/name": {{ include "swaggereditor.fullname" . }}
+    "helm.sh/chart": {{ include "swaggereditor.chart" . }}
     "app.kubernetes.io/instance": {{ .Release.Name }}
-    "app.kubernetes.io/component": {{ include "catalyst-dashboard.fullname" . }}-deployment
+    "app.kubernetes.io/component": {{ include "swaggereditor.fullname" . }}-deployment
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "catalyst-dashboard.name" . }}
+      app: {{ include "swaggereditor.name" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ include "catalyst-dashboard.name" . }}
+        app: {{ include "swaggereditor.name" . }}
         release: {{ .Release.Name }}
-        "app.kubernetes.io/name": {{ include "catalyst-dashboard.name" . }}
+        "app.kubernetes.io/name": {{ include "swaggereditor.name" . }}
         "helm.sh/chart": {{ printf "%s-%s" .Chart.Name .Chart.Version }}
-        "app.kubernetes.io/instance": {{ include "catalyst-dashboard.name" . }}
-        "app.kubernetes.io/component": {{ include "catalyst-dashboard.name" . }}-pod
+        "app.kubernetes.io/instance": {{ include "swaggereditor.name" . }}
+        "app.kubernetes.io/component": {{ include "swaggereditor.name" . }}-pod
     spec:
-      serviceAccountName: {{ include "catalyst-dashboard.name" . }}
+      serviceAccountName: {{ include "swaggereditor.name" . }}
       volumes:
         - name: cache
           emptyDir: {}
@@ -62,7 +62,7 @@ spec:
           args:
             - --https-address=:8443
             - --provider=openshift
-            - --openshift-service-account={{ printf "%s-agent" (include "catalyst-dashboard.name" .) }}
+            - --openshift-service-account={{ printf "%s-agent" (include "swaggereditor.name" .) }}
             - --upstream=http://localhost:{{ .Values.image.port }}
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key

--- a/stable/swaggereditor/templates/ingress.yaml
+++ b/stable/swaggereditor/templates/ingress.yaml
@@ -1,5 +1,5 @@
-{{- if eq .Values.clusterType "openshift" -}}
-{{- $fullName := include "catalyst-dashboard.fullname" . -}}
+{{- if eq .Values.clusterType "kubernetes" -}}
+{{- $fullName := include "swaggereditor.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $host := printf "%s.%s" .Values.host .Values.ingressSubdomain -}}
 apiVersion: networking.k8s.io/v1beta1
@@ -7,14 +7,14 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    app: {{ template "catalyst-dashboard.name" . }}
-    chart: {{ template "catalyst-dashboard.chart" . }}
+    app: {{ template "swaggereditor.name" . }}
+    chart: {{ template "swaggereditor.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    "app.kubernetes.io/name": {{ include "catalyst-dashboard.fullname" . }}
-    "helm.sh/chart": {{ include "catalyst-dashboard.chart" . }}
+    "app.kubernetes.io/name": {{ include "swaggereditor.fullname" . }}
+    "helm.sh/chart": {{ include "swaggereditor.chart" . }}
     "app.kubernetes.io/instance": {{ .Release.Name }}
-    "app.kubernetes.io/component": {{ include "catalyst-dashboard.fullname" . }}-deployment
+    "app.kubernetes.io/component": {{ include "swaggereditor.fullname" . }}-deployment
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/stable/swaggereditor/templates/role-binding.yaml
+++ b/stable/swaggereditor/templates/role-binding.yaml
@@ -1,21 +1,21 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "catalyst-dashboard.name" . }}-agent
+  name: {{ template "swaggereditor.name" . }}-agent
   labels:
-    app: {{ template "catalyst-dashboard.name" . }}
-    chart: {{ template "catalyst-dashboard.chart" . }}
+    app: {{ template "swaggereditor.name" . }}
+    chart: {{ template "swaggereditor.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    "app.kubernetes.io/name": {{ include "catalyst-dashboard.fullname" . }}
-    "helm.sh/chart": {{ include "catalyst-dashboard.chart" . }}
+    "app.kubernetes.io/name": {{ include "swaggereditor.fullname" . }}
+    "helm.sh/chart": {{ include "swaggereditor.chart" . }}
     "app.kubernetes.io/instance": {{ .Release.Name }}
-    "app.kubernetes.io/component": {{ include "catalyst-dashboard.fullname" . }}-deployment
+    "app.kubernetes.io/component": {{ include "swaggereditor.fullname" . }}-deployment
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "catalyst-dashboard.name" . }}-agent
+  name: {{ template "swaggereditor.name" . }}-agent
 subjects:
   - kind: ServiceAccount
-    name: {{ template "catalyst-dashboard.name" . }}
+    name: {{ template "swaggereditor.name" . }}
     namespace: {{ .Release.Namespace }}

--- a/stable/swaggereditor/templates/role.yaml
+++ b/stable/swaggereditor/templates/role.yaml
@@ -1,17 +1,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "catalyst-dashboard.name" . }}-agent
+  name: {{ template "swaggereditor.name" . }}-agent
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "catalyst-dashboard.name" . }}
-    chart: {{ template "catalyst-dashboard.chart" . }}
+    app: {{ template "swaggereditor.name" . }}
+    chart: {{ template "swaggereditor.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    "app.kubernetes.io/name": {{ include "catalyst-dashboard.fullname" . }}
-    "helm.sh/chart": {{ include "catalyst-dashboard.chart" . }}
+    "app.kubernetes.io/name": {{ include "swaggereditor.fullname" . }}
+    "helm.sh/chart": {{ include "swaggereditor.chart" . }}
     "app.kubernetes.io/instance": {{ .Release.Name }}
-    "app.kubernetes.io/component": {{ include "catalyst-dashboard.fullname" . }}-deployment
+    "app.kubernetes.io/component": {{ include "swaggereditor.fullname" . }}-deployment
 rules:
   - apiGroups:
       - security.openshift.io

--- a/stable/swaggereditor/templates/route.yaml
+++ b/stable/swaggereditor/templates/route.yaml
@@ -1,21 +1,21 @@
 {{- if or (eq .Values.clusterType "openshift") (regexFind "^ocp.*" .Values.clusterType) }}
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ .Values.host }}
   labels:
-    app: {{ template "catalyst-dashboard.name" . }}
-    chart: {{ template "catalyst-dashboard.chart" . }}
+    app: {{ template "swaggereditor.name" . }}
+    chart: {{ template "swaggereditor.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    "app.kubernetes.io/name": {{ include "catalyst-dashboard.fullname" . }}
-    "helm.sh/chart": {{ include "catalyst-dashboard.chart" . }}
+    "app.kubernetes.io/name": {{ include "swaggereditor.fullname" . }}
+    "helm.sh/chart": {{ include "swaggereditor.chart" . }}
     "app.kubernetes.io/instance": {{ .Release.Name }}
-    "app.kubernetes.io/component": {{ include "catalyst-dashboard.fullname" . }}-deployment
+    "app.kubernetes.io/component": {{ include "swaggereditor.fullname" . }}-deployment
 spec:
   to:
     kind: Service
-    name: {{ include "catalyst-dashboard.fullname" . }}
+    name: {{ include "swaggereditor.fullname" . }}
     weight: 100
   port:
     targetPort: {{ include "swaggereditor.route-port" . }}

--- a/stable/swaggereditor/templates/scc.yaml
+++ b/stable/swaggereditor/templates/scc.yaml
@@ -1,0 +1,43 @@
+{{- if or (eq .Values.clusterType "openshift") (regexFind "^ocp.*" .Values.clusterType) }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'privileged allows access to all privileged and host
+      features and the ability to run as any user, any group, any fsGroup, and with
+      any SELinux context.  WARNING: this is the most relaxed SCC and should be used
+      only for cluster administration. Grant with caution.'
+  name: {{ printf "privileged-%s" (include "swaggereditor.name" .) }}
+  labels:
+    app: {{ template "swaggereditor.name" . }}
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+  - '*'
+allowedUnsafeSysctls:
+  - '*'
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+  - {{ printf "system:serviceaccount:%s:%s" (.Release.Namespace) (include "swaggereditor.name" .) }}
+volumes:
+  - '*'
+{{- end }}

--- a/stable/swaggereditor/templates/service-account.yaml
+++ b/stable/swaggereditor/templates/service-account.yaml
@@ -1,16 +1,16 @@
-{{- $chartName := include "catalyst-dashboard.name" . | quote }}
+{{- $chartName := include "swaggereditor.name" . | quote }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "catalyst-dashboard.name" . }}
+  name: {{ include "swaggereditor.name" . }}
   annotations:
     serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":{{ .Values.host | quote }}}}'
   labels:
-    app: {{ template "catalyst-dashboard.name" . }}
-    chart: {{ template "catalyst-dashboard.chart" . }}
+    app: {{ template "swaggereditor.name" . }}
+    chart: {{ template "swaggereditor.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    "app.kubernetes.io/name": {{ include "catalyst-dashboard.fullname" . }}
-    "helm.sh/chart": {{ include "catalyst-dashboard.chart" . }}
+    "app.kubernetes.io/name": {{ include "swaggereditor.fullname" . }}
+    "helm.sh/chart": {{ include "swaggereditor.chart" . }}
     "app.kubernetes.io/instance": {{ .Release.Name }}
-    "app.kubernetes.io/component": {{ include "catalyst-dashboard.fullname" . }}-deployment
+    "app.kubernetes.io/component": {{ include "swaggereditor.fullname" . }}-deployment

--- a/stable/swaggereditor/templates/service.yaml
+++ b/stable/swaggereditor/templates/service.yaml
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "catalyst-dashboard.fullname" . }}
+  name: {{ include "swaggereditor.fullname" . }}
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: {{ .Values.host }}-tls
   labels:
-    app: {{ template "catalyst-dashboard.name" . }}
-    chart: {{ template "catalyst-dashboard.chart" . }}
+    app: {{ template "swaggereditor.name" . }}
+    chart: {{ template "swaggereditor.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    "app.kubernetes.io/name": {{ include "catalyst-dashboard.fullname" . }}
-    "helm.sh/chart": {{ include "catalyst-dashboard.chart" . }}
+    "app.kubernetes.io/name": {{ include "swaggereditor.fullname" . }}
+    "helm.sh/chart": {{ include "swaggereditor.chart" . }}
     "app.kubernetes.io/instance": {{ .Release.Name }}
-    "app.kubernetes.io/component": {{ include "catalyst-dashboard.fullname" . }}-deployment
+    "app.kubernetes.io/component": {{ include "swaggereditor.fullname" . }}-deployment
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -27,5 +27,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ include "catalyst-dashboard.name" . }}
+    app: {{ include "swaggereditor.name" . }}
     release: {{ .Release.Name }}

--- a/stable/swaggereditor/values.yaml
+++ b/stable/swaggereditor/values.yaml
@@ -1,4 +1,4 @@
-# Default values for catalyst-dashboard.
+# Default values for swaggereditor.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 


### PR DESCRIPTION
- Renames helper templates to match chart name
- Adds scc for openshift install
- Fixes clusterType test in ingress
- Updates apiVersion in route to allow deployment with kubectl apply

ibm-garage-cloud/planning#123