### PR TITLE
tool-config: v0.7.0

### DIFF
--- a/stable/tool-config/Chart.yaml
+++ b/stable/tool-config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to create a ConfigMap and Secret containing the configuration information for a deployed tool
 name: tool-config
-version: 0.6.0
+version: 0.7.0

--- a/stable/tool-config/templates/application-menu.yaml
+++ b/stable/tool-config/templates/application-menu.yaml
@@ -1,4 +1,4 @@
-{{- if and (include "tool-config.ingressSubdomain" .) .Values.applicationMenu }}
+{{- if and (and (include "tool-config.ingressSubdomain" .) .Values.applicationMenu) (or (eq .Values.global.clusterType "") (eq .Values.global.clusterType "ocp4")) }}
 apiVersion: console.openshift.io/v1
 kind: ConsoleLink
 metadata:

--- a/stable/tool-config/values.yaml
+++ b/stable/tool-config/values.yaml
@@ -4,6 +4,7 @@
 
 global:
   ingressSubdomain: ""
+  clusterType: ""
 
 # the name of the application the config is part of (used for app label)
 app: ""


### PR DESCRIPTION
- Adds global.clusterType to values that is used as optional check for application menu creation (moves test for clusterType == ocp4 into chart)