### PR TITLE
developer-dashboard: v1.1.0

### DIFF
--- a/stable/developer-dashboard/Chart.yaml
+++ b/stable/developer-dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: developer-dashboard
-version: 1.0.0
+version: 1.1.0

--- a/stable/developer-dashboard/templates/route.yaml
+++ b/stable/developer-dashboard/templates/route.yaml
@@ -14,4 +14,21 @@ spec:
     name: {{ include "developer-dashboard.fullname" . }}
   tls:
     termination: {{ include "developer-dashboard.route-termination" . }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ printf "%s-icons" .Values.host }}
+  labels:
+    app: {{ include "developer-dashboard.name" . }}
+spec:
+  host: {{ printf "%s-icons.%s" .Values.host (include "developer-dashboard.ingressSubdomain" .) }}
+  path: /tools
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: {{ include "developer-dashboard.fullname" . }}
+  tls:
+    termination: {{ include "developer-dashboard.route-termination" . }}
 {{- end }}

--- a/stable/developer-dashboard/values.yaml
+++ b/stable/developer-dashboard/values.yaml
@@ -18,7 +18,7 @@ sso:
 
 image:
   repository: ibmgaragecloud/developer-dashboard
-  tag: 1.0.31
+  tag: 1.1.0
   pullPolicy: IfNotPresent
   port: 3000
 


### PR DESCRIPTION
- Adds route for icons
- Bumps image version to v1.1.0

ibm-garage-cloud/planning#414