### PR TITLE
developer-dashboard: v1.1.1

### DIFF
--- a/stable/developer-dashboard/Chart.yaml
+++ b/stable/developer-dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: developer-dashboard
-version: 1.1.0
+version: 1.1.1

--- a/stable/developer-dashboard/templates/route.yaml
+++ b/stable/developer-dashboard/templates/route.yaml
@@ -30,5 +30,5 @@ spec:
     kind: Service
     name: {{ include "developer-dashboard.fullname" . }}
   tls:
-    termination: {{ include "developer-dashboard.route-termination" . }}
+    termination: edge
 {{- end }}

--- a/stable/developer-dashboard/values.yaml
+++ b/stable/developer-dashboard/values.yaml
@@ -18,7 +18,7 @@ sso:
 
 image:
   repository: ibmgaragecloud/developer-dashboard
-  tag: 1.1.0
+  tag: 1.1.1
   pullPolicy: IfNotPresent
   port: 3000
 


### PR DESCRIPTION
- Changes `icons` route to use edge termination to fix issue
- Bumps image tag to 1.1.1

ibm-garage-cloud/planning#414