### PR TITLE
service-mesh-operator: v0.2.0

### DIFF
--- a/stable/service-mesh-operator/Chart.yaml
+++ b/stable/service-mesh-operator/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/service-mesh-operator/templates/instance.yaml
+++ b/stable/service-mesh-operator/templates/instance.yaml
@@ -1,34 +1,17 @@
+{{- if .Values.createInstance -}}
 {{- if eq (include "operator.cluster-type" .) "ocp4" }}
 apiVersion: maistra.io/v1
 kind: ServiceMeshControlPlane
 metadata:
-  name: basic-install
-  namespace: tools
+  name: {{ include "operator.name" . }}
 spec:
-  version: v1.1
-  istio:
-    gateways:
-      istio-egressgateway:
-        autoscaleEnabled: false
-      istio-ingressgateway:
-        autoscaleEnabled: false
-        ior_enabled: false
-    mixer:
-      policy:
-        autoscaleEnabled: false
-      telemetry:
-        autoscaleEnabled: false
-    pilot:
-      autoscaleEnabled: false
-      traceSampling: 100
-    kiali:
-      enabled: true
-    grafana:
-      enabled: true
-    tracing:
-      enabled: true
-      jaeger:
-        template: all-in-one
+{{ .Values.ocpSpec | toYaml | indent 2 }}
 {{- else -}}
-
+apiVersion: istio.banzaicloud.io/v1beta1
+kind: Istio
+metadata:
+  name: {{ include "operator.name" . }}
+spec:
+{{ .Values.iksSpec | toYaml | indent 2 }}
+{{- end -}}
 {{- end -}}

--- a/stable/service-mesh-operator/values.yaml
+++ b/stable/service-mesh-operator/values.yaml
@@ -21,3 +21,89 @@ operatorHub:
   source: operatorhubio-catalog
   channel: beta
   name: istio
+
+createInstance: true
+
+ocpSpec:
+  version: v1.1
+  istio:
+    gateways:
+      istio-egressgateway:
+        autoscaleEnabled: false
+      istio-ingressgateway:
+        autoscaleEnabled: false
+        ior_enabled: false
+    mixer:
+      policy:
+        autoscaleEnabled: false
+      telemetry:
+        autoscaleEnabled: false
+    pilot:
+      autoscaleEnabled: false
+      traceSampling: 100
+    kiali:
+      enabled: true
+    grafana:
+      enabled: true
+    tracing:
+      enabled: true
+      jaeger:
+        template: all-in-one
+
+iksSpec:
+  autoInjectionNamespaces:
+    - default
+  citadel:
+    image: 'docker.io/istio/citadel:1.1.2'
+    replicaCount: 1
+  defaultPodDisruptionBudget:
+    enabled: true
+  galley:
+    image: 'docker.io/istio/galley:1.1.2'
+    replicaCount: 1
+  gateways:
+    egress:
+      maxReplicas: 5
+      minReplicas: 1
+      replicaCount: 1
+      sds:
+        image: node-agent-k8s
+    ingress:
+      maxReplicas: 5
+      minReplicas: 1
+      replicaCount: 1
+      sds:
+        image: node-agent-k8s
+    k8singress: {}
+  imageHub: docker.io/istio
+  imageTag: 1.1.0
+  includeIPRanges: '*'
+  mixer:
+    image: 'docker.io/istio/mixer:1.1.2'
+    maxReplicas: 5
+    minReplicas: 1
+    replicaCount: 1
+  mtls: false
+  nodeAgent:
+    image: 'docker.io/istio/node-agent-k8s:1.1.2'
+  outboundTrafficPolicy:
+    mode: ALLOW_ANY
+  pilot:
+    image: 'docker.io/istio/pilot:1.1.2'
+    maxReplicas: 5
+    minReplicas: 1
+    replicaCount: 1
+    traceSampling: 1
+  proxy:
+    image: 'docker.io/istio/proxyv2:1.1.2'
+  proxyInit:
+    image: 'docker.io/istio/proxy_init:1.1.2'
+  sds: {}
+  sidecarInjector:
+    image: 'docker.io/istio/sidecar_injector:1.1.2'
+    replicaCount: 1
+    rewriteAppHTTPProbe: true
+  tracing:
+    zipkin:
+      address: 'zipkin.istio-system:9411'
+  version: 1.1.2


### PR DESCRIPTION
- Extracts instance spec into values.yaml
- Adds instance logic for iks install
- Adds createInstance flag (defaulted to true) to have parity with other charts