### PR TITLE
add tool-test chart

### DIFF
--- a/stable/tool-test/.helmignore
+++ b/stable/tool-test/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/tool-test/Chart.yaml
+++ b/stable/tool-test/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+name: tool-test
+description: A Helm chart for Kubernetes to test tool kit deployments
+version: 0.1.0

--- a/stable/tool-test/templates/_helpers.tpl
+++ b/stable/tool-test/templates/_helpers.tpl
@@ -1,0 +1,90 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tool-test.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tool-test.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tool-test.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create service name.
+*/}}
+{{- define "tool-test.service-name" -}}
+{{- $fullName := include "tool-test.fullname" . -}}
+{{- printf "%s-%s" .Values.service.name $fullName | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "tool-test.ingressSubdomain" -}}
+{{- default .Values.global.ingressSubdomain .Values.ingress.subdomain -}}
+{{- end -}}
+
+{{- define "tool-test.ingress-host" -}}
+{{- $ingressSubdomain := include "tool-test.ingressSubdomain" . -}}
+{{- if .Values.ingress.includeNamespace -}}
+{{- printf "%s-%s.%s" .Values.host .Release.Namespace $ingressSubdomain -}}
+{{- else -}}
+{{- printf "%s.%s" .Values.host $ingressSubdomain -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tool-test.route-termination" -}}
+{{- if .Values.sso.enabled -}}
+{{ printf "reencrypt" }}
+{{- else -}}
+{{ printf "edge" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "tool-test.clusterType" -}}
+{{ $clusterType := default .Values.global.clusterType .Values.clusterType }}
+{{- if or (eq $clusterType "openshift") (regexFind "^ocp.*" $clusterType) -}}
+{{- "openshift" -}}
+{{- else -}}
+{{- "kubernetes" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "tool-test.labels" -}}
+helm.sh/chart: {{ include "tool-test.chart" . }}
+{{ include "tool-test.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tool-test.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tool-test.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/stable/tool-test/templates/ingress.yaml
+++ b/stable/tool-test/templates/ingress.yaml
@@ -1,0 +1,28 @@
+{{- $clusterType := include "tool-test.clusterType" . -}}
+{{- if and (.Values.ingress.enabled) (eq $clusterType "kubernetes") -}}
+{{- $fullName := include "tool-test.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- $host := include "tool-test.ingress-host" . -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "tool-test.name" . }}
+    chart: {{ template "tool-test.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+ rules:
+ - host: {{ $host }}
+   http:
+     paths:
+     - path: {{ $ingressPath }}
+       backend:
+         serviceName: {{ include "tool-test.service-name" . }}
+         servicePort: {{ .Values.service.portName }}
+{{- end }}

--- a/stable/tool-test/templates/route.yaml
+++ b/stable/tool-test/templates/route.yaml
@@ -1,0 +1,18 @@
+{{- $clusterType := include "tool-test.clusterType" . -}}
+{{- if (eq $clusterType "openshift") }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "tool-test.fullname" . }}
+  labels:
+    app: {{ include "tool-test.name" . }}
+    chart: {{ include "tool-test.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  port:
+    targetPort: {{ .Values.service.portName }}
+  to:
+    kind: Service
+    name: {{ include "tool-test.service-name" . }}
+{{- end }}

--- a/stable/tool-test/templates/service.yaml
+++ b/stable/tool-test/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tool-test.service-name" . }}
+  labels:
+    app: {{ include "tool-test.name" . }}
+    chart: {{ include "tool-test.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: {{ .Values.service.portName }}
+  selector:
+    app: {{ include "tool-test.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/tool-test/values.yaml
+++ b/stable/tool-test/values.yaml
@@ -1,0 +1,33 @@
+# Default values for tool-test.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+global:
+  clusterType: "kubernetes"
+
+host: "tooltest"
+
+service:
+  name: dummy-service
+  port: 80
+  targetPort: http
+  portName: http
+
+ingress:
+  enabled: true
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /dummy
+  includeNamespace: true
+  subdomain: "com"
+
+configMaps: []
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
fixes ibm-garage-cloud/planning#352

Creates a helm chart that installs a 'dummy' ingress (on IKS), route (on OCP) and service (on both) to verify destroy does not delete them.