### PR TITLE
tool-config: v0.8.1

### DIFF
--- a/stable/tool-config/Chart.yaml
+++ b/stable/tool-config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to create a ConfigMap and Secret containing the configuration information for a deployed tool
 name: tool-config
-version: 0.8.0
+version: 0.8.1

--- a/stable/tool-config/templates/_helpers.tpl
+++ b/stable/tool-config/templates/_helpers.tpl
@@ -35,6 +35,30 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "tool-config.labels" -}}
+helm.sh/chart: {{ include "tool-config.chart" . }}
+app: {{ include "tool-config.app" . }}
+release: {{ .Release.Name | quote }}
+app.kubernetes.io/part-of: {{ include "tool-config.app" . }}
+app.kubernetes.io/component: {{ .Values.component | quote }}
+group: {{ .Values.group | quote }}
+grouping: {{ .Values.grouping | quote }}
+{{ include "tool-config.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tool-config.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tool-config.app" . }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.

--- a/stable/tool-config/templates/application-menu.yaml
+++ b/stable/tool-config/templates/application-menu.yaml
@@ -4,16 +4,7 @@ kind: ConsoleLink
 metadata:
   name: {{ printf "toolkit-%s" (include "tool-config.name" .) }}
   labels:
-    app: {{ include "tool-config.app" . }}
-    app.kubernetes.io/name: {{ include "tool-config.app" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.Version | quote }}
-    app.kubernetes.io/part-of: {{ include "tool-config.app" . }}
-    app.kubernetes.io/component: {{ .Values.component | quote }}
-    chart: {{ include "tool-config.chart" . }}
-    release: {{ .Release.Name | quote }}
-    group: {{ .Values.group | quote }}
-    grouping: {{ .Values.grouping | quote }}
+{{ include "tool-config.labels" . | indent 4 }}
 spec:
   applicationMenu:
     imageURL: {{ include "tool-config.imageUrl" . }}

--- a/stable/tool-config/templates/config-map.yaml
+++ b/stable/tool-config/templates/config-map.yaml
@@ -4,16 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "tool-config.config-name" . }}
   labels:
-    app: {{ include "tool-config.app" . }}
-    app.kubernetes.io/name: {{ include "tool-config.app" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.Version | quote }}
-    app.kubernetes.io/part-of: {{ include "tool-config.app" . }}
-    app.kubernetes.io/component: {{ .Values.component | quote }}
-    chart: {{ include "tool-config.chart" . }}
-    release: {{ .Release.Name | quote }}
-    group: {{ .Values.group | quote }}
-    grouping: {{ .Values.grouping | quote }}
+{{ include "tool-config.labels" . | indent 4 }}
   annotations:
     description: {{ printf "Config map to hold the url for %s in the environment so that other components can access it" (include "tool-config.name" .) }}
 data:

--- a/stable/tool-config/templates/secret.yaml
+++ b/stable/tool-config/templates/secret.yaml
@@ -5,16 +5,7 @@ kind: Secret
 metadata:
   name: {{ include "tool-config.secret-name" . }}
   labels:
-    app: {{ include "tool-config.app" . }}
-    app.kubernetes.io/name: {{ include "tool-config.app" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.Version | quote }}
-    app.kubernetes.io/part-of: {{ include "tool-config.app" . }}
-    app.kubernetes.io/component: {{ .Values.component | quote }}
-    chart: {{ include "tool-config.chart" . }}
-    release: {{ .Release.Name | quote }}
-    group: {{ .Values.group | quote }}
-    grouping: {{ .Values.grouping | quote }}
+{{ include "tool-config.labels" . | indent 4 }}
   annotations:
     description: {{ printf "Secret to hold the username and password for %s so that other components can access it" (include "tool-config.name" .) }}
 type: Opaque


### PR DESCRIPTION
- Adds standard labels for all resources, particularly the helm.sh/chart and managed-by labels