### PR TITLE
ibmcloud: v0.2.0

### DIFF
--- a/stable/ibmcloud/Chart.yaml
+++ b/stable/ibmcloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for to create a ConfigMap and Secret containing information about the IBM Cloud environment
 name: ibmcloud
-version: 0.1.5
+version: 0.2.0

--- a/stable/ibmcloud/templates/_helpers.tpl
+++ b/stable/ibmcloud/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "ibmcloud.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default "cloud" .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "ibmcloud.config-name" -}}
@@ -11,7 +11,7 @@ Expand the name of the chart.
 {{- end -}}
 
 {{- define "ibmcloud.apikey-name" -}}
-{{- printf "%s-%s" (include "ibmcloud.name" .) "apikey" -}}
+{{- printf "%s-%s" (include "ibmcloud.name" .) "access" -}}
 {{- end -}}
 
 {{/*
@@ -77,3 +77,29 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Common labels
+*/}}
+{{- define "ibmcloud.labels" -}}
+helm.sh/chart: {{ include "ibmcloud.chart" . }}
+app: {{ include "ibmcloud.name" . }}
+release: {{ .Release.Name | quote }}
+app.kubernetes.io/part-of: {{ include "ibmcloud.name" . }}
+app.kubernetes.io/component: {{ .Values.component | quote }}
+group: {{ .Values.group | quote }}
+grouping: {{ .Values.grouping | quote }}
+{{ include "ibmcloud.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ibmcloud.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ibmcloud.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- end -}}

--- a/stable/ibmcloud/templates/config-map.yaml
+++ b/stable/ibmcloud/templates/config-map.yaml
@@ -1,16 +1,32 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: ibmcloud-config
+  labels:
+{{ include "ibmcloud.labels" . | indent 4 }}
+  annotations:
+    description: "ConfigMap to hold the ibmcloud configuration values used to access the cluster environment (so that processes within the cluster can operate on the cluster)"
+data:
+  CLUSTER_TYPE: {{ include "ibmcloud.cluster_type" . }}
+  APIURL: {{ .Values.apiurl | quote }}
+  REGISTRY_URL: {{ .Values.registry_url | quote }}
+  REGION: {{ .Values.region | quote }}
+  SERVER_URL: {{ required "The 'server_url' is required!" .Values.server_url | quote }}
+  RESOURCE_GROUP: {{ required "The 'resource_group' is required!" .Values.resource_group | quote }}
+  INGRESS_SUBDOMAIN: {{ required "The 'ingress_subdomain' is required!" .Values.ingress_subdomain | quote }}
+  REGISTRY_NAMESPACE: {{ include "ibmcloud.registry_namespace" . }}
+  CLUSTER_NAME: {{ include "ibmcloud.cluster_name" . }}
+  TLS_SECRET_NAME: {{ .Values.tls_secret_name | quote }}
+  {{- if .Values.cluster_version }}
+  CLUSTER_VERSION: {{ .Values.cluster_version | quote }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: {{ include "ibmcloud.config-name" . }}
   labels:
-    app: {{ include "ibmcloud.name" . }}
-    app.kubernetes.io/name: {{ include "ibmcloud.name" . }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
-    app.kubernetes.io/part-of: {{ .Values.app }}
-    chart: {{ include "ibmcloud.chart" . }}
-    release: {{ .Release.Name }}
-    group: {{ .Values.group }}
-    grouping: {{ .Values.grouping }}
+  {{ include "ibmcloud.labels" . | indent 4 }}
   annotations:
     description: "ConfigMap to hold the ibmcloud configuration values used to access the cluster environment (so that processes within the cluster can operate on the cluster)"
 data:

--- a/stable/ibmcloud/templates/secret.yaml
+++ b/stable/ibmcloud/templates/secret.yaml
@@ -1,16 +1,23 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  name: ibmcloud-apikey
+  labels:
+{{ include "ibmcloud.labels" . | indent 4 }}
+  annotations:
+    description: "Secret to hold the ibmcloud apikey used to access the cluster environment (so that processes within the cluster can operate on the cluster)"
+type: Opaque
+stringData:
+  APIKEY: {{ required "A valid 'apikey' entry is required!" .Values.apikey }}
+  REGISTRY_USER: {{ .Values.registry_user | quote }}
+  REGISTRY_PASSWORD: {{ include "ibmcloud.registry_password" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: {{ include "ibmcloud.apikey-name" . }}
   labels:
-    app: {{ include "ibmcloud.name" . }}
-    app.kubernetes.io/name: {{ include "ibmcloud.name" . }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
-    app.kubernetes.io/part-of: {{ .Values.app }}
-    chart: {{ include "ibmcloud.chart" . }}
-    release: {{ .Release.Name }}
-    group: {{ .Values.group }}
-    grouping: {{ .Values.grouping }}
+  {{ include "ibmcloud.labels" . | indent 4 }}
   annotations:
     description: "Secret to hold the ibmcloud apikey used to access the cluster environment (so that processes within the cluster can operate on the cluster)"
 type: Opaque


### PR DESCRIPTION
- Adds helper template for common labels
- Generates configmap and secret with new names (cloud-config and cloud-access) but leaves old ones for now for backward compatibility