### PR TITLE
argocd-config: v0.13.1

### DIFF
--- a/stable/argocd-config/Chart.yaml
+++ b/stable/argocd-config/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.13.0
+version: 0.13.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/argocd-config/templates/applications.yaml
+++ b/stable/argocd-config/templates/applications.yaml
@@ -2,6 +2,7 @@
 {{- $releaseNamespace := .Release.Namespace -}}
 {{- $targetRepo := .Values.repoUrl -}}
 {{- $project := default "default" .Values.project -}}
+{{- $labels := include "argocd.labels" . -}}
 {{- range .Values.applicationTargets }}
 {{- $targetNamespace := .targetNamespace -}}
 {{- $targetRevision := .targetRevision -}}
@@ -17,7 +18,7 @@ metadata:
   name: {{ printf "%s-%s" $targetRevision $name }}
   namespace: {{ $releaseNamespace }}
   labels:
-{{ include "argocd.labels" . | indent 4 }}
+{{ $labels  | indent 4 }}
 spec:
   destination:
     namespace: {{ $targetNamespace }}

--- a/stable/argocd-config/templates/namespaces.yaml
+++ b/stable/argocd-config/templates/namespaces.yaml
@@ -1,4 +1,5 @@
 {{- $clusterType := .Values.clusterType -}}
+{{- $labels := include "argocd.labels" . -}}
 {{- range .Values.applicationTargets }}
 {{ $namespace := .targetNamespace }}
 {{- if or (or (eq $clusterType "ocp3") (eq $clusterType "openshift")) ((eq $clusterType "ocp4")) -}}
@@ -12,7 +13,7 @@ kind: Namespace
 metadata:
   name: {{ $namespace }}
   labels:
-{{ include "argocd.labels" . | indent 4 }}
+{{ $labels | indent 4 }}
 {{- end }}
 ---
 {{- end -}}

--- a/stable/argocd-config/templates/project.yaml
+++ b/stable/argocd-config/templates/project.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "argocd.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
 spec:
   sourceRepos:
   - '*'


### PR DESCRIPTION
- Fixes issue with using the label template in a loop
- Adds pre-install helm hook annotation to project to fix timing issue in Argo with applications created before project