### PR TITLE
cloud-setup: v0.1.0

### DIFF
--- a/stable/cloud-setup/.helmignore
+++ b/stable/cloud-setup/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/cloud-setup/Chart.yaml
+++ b/stable/cloud-setup/Chart.yaml
@@ -1,0 +1,42 @@
+apiVersion: v2
+name: cloud-setup
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.0
+
+dependencies:
+  - name: ibmcloud
+    version: 0.2.2
+    repository: https://ibm-garage-cloud.github.io/toolkit-charts/
+  - name: tool-config
+    version: 0.9.0
+    repository: https://ibm-garage-cloud.github.io/toolkit-charts/
+    alias: github-config
+  - name: tool-config
+    version: 0.9.0
+    repository: https://ibm-garage-cloud.github.io/toolkit-charts/
+    alias: imageregistry-config
+  - name: doc-config
+    version: 0.1.0
+    repository: https://ibm-garage-cloud.github.io/toolkit-charts/
+    alias: cntk-dev-guide
+  - name: doc-config
+    version: 0.1.0
+    repository: https://ibm-garage-cloud.github.io/toolkit-charts/
+    alias: first-app

--- a/stable/cloud-setup/values.yaml
+++ b/stable/cloud-setup/values.yaml
@@ -1,0 +1,17 @@
+# Default values for cloud-setup.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+global:
+  clusterType: ""
+  ingressSubdomain: ""
+  tlsSecretName: ""
+
+ibmcloud: {}
+
+github-config: {}
+
+imageregistry-config: {}
+
+cntk-dev-guide: {}
+
+first-app: {}


### PR DESCRIPTION
- Adds intial version of cloud-setup chart that creates ibmcloud, github, imageregistry, cloudnative toolkit doc config, and first-app doc config

ibm-garage-cloud/planning#501