### PR TITLE
service-account v0.6.0: Adds helm pre-install hooks to prevent timing…

### DIFF
--- a/stable/service-account/Chart.yaml
+++ b/stable/service-account/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/service-account/templates/scc-anyuid.yaml
+++ b/stable/service-account/templates/scc-anyuid.yaml
@@ -9,6 +9,8 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "-3"
     argocd.argoproj.io/sync-options: Validate=false
     kubernetes.io/description: anyuid provides all features of the restricted SCC
       but allows users to run with any UID and any GID.

--- a/stable/service-account/templates/scc-privileged.yaml
+++ b/stable/service-account/templates/scc-privileged.yaml
@@ -9,6 +9,8 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "-3"
     argocd.argoproj.io/sync-options: Validate=false
     kubernetes.io/description: 'privileged allows access to all privileged and host
       features and the ability to run as any user, any group, any fsGroup, and with

--- a/stable/service-account/templates/serviceaccount.yaml
+++ b/stable/service-account/templates/serviceaccount.yaml
@@ -4,6 +4,9 @@ kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "service-account.name" . }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "-5"
   labels:
 {{- include "service-account.labels" . | nindent 4 }}
 {{- end -}}


### PR DESCRIPTION
There is a timing issue/race condition that happens if the deployment/pod that uses the service account is created before the 
scc is applied to the service account. The condition will eventually resolve itself but the immediate deployment appears to fail because the scc has not been applied.

The pre-install hooks *should* change the order in which the resources are created.