### PR TITLE
setup-job: v0.2.0

### DIFF
--- a/stable/setup-job/Chart.yaml
+++ b/stable/setup-job/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.7
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.16.0
+appVersion: 0.0.0

--- a/stable/setup-job/templates/job.yaml
+++ b/stable/setup-job/templates/job.yaml
@@ -29,7 +29,7 @@ spec:
                   command: ["bash"]
                   args:
                     - "-c"
-                    - "npm i -g @ibmgaragecloud/cloud-native-toolkit-web-cli; $(npm config get prefix)/bin/igc-web ${COMMAND} --inCluster -n ${NAMESPACE} --debug"
+                    - "npm i -g @ibmgaragecloud/cloud-native-toolkit-web-cli@${CLI_VERSION}; $(npm config get prefix)/bin/igc-web ${COMMAND} --inCluster -n ${NAMESPACE} --debug"
                   env:
                     - name: COMMAND
                       value: {{ .Values.command }}

--- a/stable/setup-job/values.yaml
+++ b/stable/setup-job/values.yaml
@@ -8,4 +8,4 @@ command: ""
 secret:
   name: ""
   key: ""
-cliVersion: "latest"
+cliVersion: "0.3.3"


### PR DESCRIPTION
- Updates the job to use the CLI_VERSION environment variable
- Sets the cliVersion to 0.3.3 (the latest version of @ibmgaragecloud/cloud-native-toolkit-web-cli currently available