### PR TITLE
starter-kit: v0.5.0

### DIFF
--- a/stable/starter-kit/Chart.yaml
+++ b/stable/starter-kit/Chart.yaml
@@ -2,22 +2,22 @@ apiVersion: v2
 name: starter-kit
 description: A Helm chart for Kubernetes
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+## A chart can be either an 'application' or a 'library' chart.
+##
+## Application charts are a collection of templates that can be packaged into versioned archives
+## to be deployed.
+##
+## Library charts provide useful utilities or functions for the chart developer. They're included as
+## a dependency of application charts to inject those utilities and functions into the rendering
+## pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+## This is the chart version. This version number should be incremented each time you make changes
+## to the chart and its templates, including the app version.
+## Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.5.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.4.3
+## This is the version number of the application being deployed. This version number should be
+## incremented each time you make changes to the application. Versions are not expected to
+## follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.5.0

--- a/stable/starter-kit/templates/_helpers.tpl
+++ b/stable/starter-kit/templates/_helpers.tpl
@@ -38,6 +38,7 @@ app: {{ include "starter-kit.name" . }}
 helm.sh/chart: {{ include "starter-kit.chart" . }}
 {{ include "starter-kit.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
+version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/stable/starter-kit/templates/deployment.yaml
+++ b/stable/starter-kit/templates/deployment.yaml
@@ -32,12 +32,13 @@ spec:
       {{- include "starter-kit.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        sidecar.istio.io/inject: {{ .Values.istio | default true | quote }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "starter-kit.selectorLabels" . | nindent 8 }}
+        {{- include "starter-kit.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/starter-kit/values.yaml
+++ b/stable/starter-kit/values.yaml
@@ -1,6 +1,6 @@
-# Default values for starter-kit.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+## Default values for starter-kit.
+## This is a YAML-formatted file.
+## Declare variables to be passed into your templates.
 
 global:
   tlsSecretName: ""
@@ -13,7 +13,7 @@ image:
   pullPolicy: IfNotPresent
   port: 8080
   probePath: /
-  # Overrides the image tag whose default is the chart appVersion.
+  ## Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 imagePullSecrets: []
@@ -21,12 +21,12 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  ## Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
+  ## Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  ## The name of the service account to use.
+  ## If not set and create is true, a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
@@ -69,10 +69,10 @@ graphql:
   openapiPath: /openapi.json
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -100,10 +100,12 @@ vcsInfo:
 connectsTo: ""
 
 partOf: ""
-# The app.openshift.io/runtime value. The full list can be found at static/assets/ on the OpenShift cluster.
-# Any of the following values will set default resource limits: golang, js, nodejs, openjdk, openliberty, python, spring
+## The app.openshift.io/runtime value. The full list can be found at static/assets/ on the OpenShift cluster.
+## Any of the following values will set default resource limits: golang, js, nodejs, openjdk, openliberty, python, spring
 runtime: ""
 
 configMap: {}
 envFrom: {}
 env: {}
+## Value for the istio sidecar injection annotation
+istio: true


### PR DESCRIPTION
- Adds full set of labels to pod spec (not just selector labels)
- Adds `version` label to label set
- Adds `sidecar.istio.io/inject` annotation to the pods with corresponding flag

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>